### PR TITLE
Add arg (-e): use EFF wordlist instead of original

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Launch",
+            "program": "${workspaceFolder}/target/debug/sppg",
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },        
+
+    ]
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.1.8", features = ["derive"] }
+lazy_static = "1.4.0"
 rand = "0.8.5"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,6 +3,8 @@ use clap::Parser;
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct Args {
+    #[arg(short, long)]
+    pub eff_word_list: bool,
     #[arg(short, long, default_value_t = 6, value_parser = clap::value_parser!(u8).range(1..))]
     pub num_of_pass: u8,
     #[arg(short, long, default_value_t = 5, value_parser = clap::value_parser!(u8).range(1..))]
@@ -15,12 +17,14 @@ pub fn process_command_line() -> Args {
 
 #[cfg(test)]
 mod test {
+    use clap::CommandFactory;
+
     use super::*;
 
-    // #[test]
-    // fn verify_cli() {
-    //     Args::command().debug_assert()
-    // }
+    #[test]
+    fn verify_cli() {
+        Args::command().debug_assert()
+    }
 
     #[test]
     fn verify_cli_display_help() {
@@ -82,5 +86,23 @@ mod test {
             .word_count;
 
         assert_eq!(value, 5, "default -w value is 5");
+    }
+
+    #[test]
+    fn verify_cli_arg_e_defaults_to_false() {
+        let value = Args::try_parse_from(["sppg"])
+            .expect("this command is supposed to work")
+            .eff_word_list;
+
+        assert!(!value, "default -e value is false");
+    }
+
+    #[test]
+    fn verify_cli_arg_e_is_true() {
+        let value = Args::try_parse_from(["sppg", "--eff-word-list"])
+            .expect("this command is supposed to work")
+            .eff_word_list;
+
+        assert!(value, "Arg -e is set to true");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,22 +2,47 @@ use std::collections::HashMap;
 
 use rand::distributions::{Distribution, Uniform};
 
-pub mod cli;
-pub mod original_wordlist;
+#[macro_use]
+extern crate lazy_static;
 
-use crate::cli::process_command_line;
-use original_wordlist::ORIGINAL_WORDLIST;
+mod cli;
+mod eff_wordlist;
+mod original_wordlist;
+
+use crate::{
+    cli::{process_command_line, Args},
+    eff_wordlist::EFF_WORDLIST,
+    original_wordlist::ORIGINAL_WORDLIST,
+};
+
+lazy_static! {
+    static ref LIST_ORIG: HashMap<&'static str, &'static str> =
+        ORIGINAL_WORDLIST.into_iter().collect();
+}
+lazy_static! {
+    static ref LIST_EFF: HashMap<&'static str, &'static str> = EFF_WORDLIST.into_iter().collect();
+}
 
 fn main() {
     let cli_args = process_command_line();
-    let diceware_map: HashMap<&str, &str> = ORIGINAL_WORDLIST.into_iter().collect();
-    let list = iterate(cli_args.num_of_pass, cli_args.word_count, &diceware_map);
+    let list = iterate(&cli_args);
     for l in list {
         println!("{l}");
     }
 }
 
-fn iterate(iterations: u8, word_count: u8, diceware_map: &HashMap<&str, &str>) -> Vec<String> {
+fn choose_word_list(cli_args: &Args) -> &'static HashMap<&'static str, &'static str> {
+    if cli_args.eff_word_list {
+        return &LIST_EFF;
+    }
+
+    &LIST_ORIG
+}
+
+fn iterate(cli_args: &Args) -> Vec<String> {
+    let word_count = cli_args.word_count;
+    let iterations = cli_args.num_of_pass;
+    let diceware_map = choose_word_list(cli_args);
     let mut list = Vec::<String>::new();
     for _ in 0..iterations {
         let mut passphrase = String::new();
@@ -44,7 +69,10 @@ fn roll_dice() -> String {
     lookup_number
 }
 
-fn lookup_word<'a>(lookup: &str, diceware_map: &'a HashMap<&'a str, &'a str>) -> &'a str {
+fn lookup_word(
+    lookup: &str,
+    diceware_map: &'static HashMap<&'static str, &'static str>,
+) -> &'static str {
     diceware_map.get(lookup).unwrap()
 }
 
@@ -71,7 +99,8 @@ mod tests {
     fn lookup_number_retrieves_word() {
         let cases = [("11111", "a"), ("36355", "levi"), ("66666", "\"@")];
 
-        let diceware_map: HashMap<&str, &str> = ORIGINAL_WORDLIST.into_iter().collect();
+        let cli_args = process_command_line();
+        let diceware_map = choose_word_list(&cli_args);
         for (index, expected) in cases {
             let word = lookup_word(&index, &diceware_map);
             assert_eq!(
@@ -87,10 +116,9 @@ mod tests {
         let cli_args = process_command_line();
         let num_choices = cli_args.num_of_pass;
         let word_count = cli_args.word_count;
-        let diceware_map: HashMap<&str, &str> = ORIGINAL_WORDLIST.into_iter().collect();
-        let list = iterate(num_choices, word_count, &diceware_map);
+        let list = iterate(&cli_args);
 
-        assert_eq!(list.len(), 6, "number of passphrases is 6");
+        assert_eq!(list.len(), 6, "number of passphrases is {}", num_choices);
 
         for l in list {
             let list: Vec<&str> = l.split_whitespace().collect();
@@ -101,17 +129,43 @@ mod tests {
 
     #[test]
     fn iterations_and_word_count() {
-        let num_choices = 32;
+        let num_choices = 12;
         let word_count = 15;
-        let diceware_map: HashMap<&str, &str> = ORIGINAL_WORDLIST.into_iter().collect();
-        let list = iterate(num_choices, word_count, &diceware_map);
+        let mut cli_args = process_command_line();
+        cli_args.num_of_pass = num_choices;
+        cli_args.word_count = word_count;
+        let list = iterate(&cli_args);
 
-        assert_eq!(list.len(), 32, "number of passphrases is 6");
+        assert_eq!(list.len(), 12, "number of passphrases is {}", num_choices);
 
         for l in list {
             let list: Vec<&str> = l.split_whitespace().collect();
 
             assert_eq!(list.len(), 15, "words in passphrase = {}", word_count);
         }
+    }
+
+    #[test]
+    fn choose_wordlist_default() {
+        let args = process_command_line();
+        let map = choose_word_list(&args);
+        assert_eq!(
+            lookup_word(&"11111", map),
+            "a",
+            "default wordlist is the original one",
+        );
+    }
+
+    #[test]
+    fn choose_wordlist_eff() {
+        let mut args = process_command_line();
+        args.eff_word_list = true;
+        let map = choose_word_list(&args);
+
+        assert_eq!(
+            lookup_word("11111", map),
+            "abacus",
+            "when -e is used wordlist is the EFF one",
+        );
     }
 }


### PR DESCRIPTION
Both wordlist have the same amount of words so the security is exactly the same. The difference is mainly in user taste: The EFF wordlist has:
  - removed words of less than 3 characters
  - removed more words considered offensive in some contexts
  - average word length is longer
  - prioritizes familiar words over short, unusual words